### PR TITLE
Avoid rubyforge_project in gemspec

### DIFF
--- a/README
+++ b/README
@@ -93,10 +93,12 @@ INSTALL
 
 URIS
 
-  http://github.com/ahoward/tagz/tree/master
-  http://rubyforge.org/projects/codeforpeople
+  https://github.com/ahoward/tagz/tree/master
 
 HISTORY
+  7.2.0
+    - ruby19 compat
+
   7.0.0
     - * IMPORTANT * NOT BACKWARD COMPATIBLE (thus version bump)
     the tagz functionality itself has not changed, but the defaults for

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-This.rubyforge_project = 'codeforpeople'
 This.author = "Ara T. Howard"
 This.email = "ara.t.howard@gmail.com"
 This.homepage = "https://github.com/ahoward/#{ This.lib }"
@@ -89,7 +88,6 @@ task :gemspec do
   version     = This.version
   files       = shiteless[Dir::glob("**/**")]
   executables = shiteless[Dir::glob("bin/*")].map{|exe| File.basename(exe)}
-  #has_rdoc    = true #File.exist?('doc')
   test_files  = "test/#{ lib }.rb" if File.file?("test/#{ lib }.rb")
   summary     = object.respond_to?(:summary) ? object.summary : "summary: #{ lib } kicks the ass"
   description = object.respond_to?(:description) ? object.description : "description: #{ lib } kicks the ass"
@@ -145,7 +143,6 @@ task :gemspec do
 
             spec.extensions.push(*<%= extensions.inspect %>)
 
-            spec.rubyforge_project = <%= This.rubyforge_project.inspect %>
             spec.author = <%= This.author.inspect %>
             spec.email = <%= This.email.inspect %>
             spec.homepage = <%= This.homepage.inspect %>
@@ -226,12 +223,6 @@ task :release => [:clean, :gemspec, :gem] do
   raise "no gems?" if gems.size < 1
 
   cmd = "gem push #{ This.gem }"
-  puts cmd
-  puts
-  system(cmd)
-  abort("cmd(#{ cmd }) failed with (#{ $?.inspect })") unless $?.exitstatus.zero?
-
-  cmd = "rubyforge login && rubyforge add_release #{ This.rubyforge_project } #{ This.lib } #{ This.version } #{ This.gem }"
   puts cmd
   puts
   system(cmd)

--- a/readme.erb
+++ b/readme.erb
@@ -93,8 +93,7 @@ INSTALL
 
 URIS
 
-  http://github.com/ahoward/tagz/tree/master
-  http://rubyforge.org/projects/codeforpeople
+  https://github.com/ahoward/tagz/tree/master
 
 HISTORY
   7.2.0

--- a/tagz.gemspec
+++ b/tagz.gemspec
@@ -39,7 +39,6 @@ Gem::Specification::new do |spec|
 
   spec.extensions.push(*[])
 
-  spec.rubyforge_project = "codeforpeople"
   spec.author = "Ara T. Howard"
   spec.email = "ara.t.howard@gmail.com"
   spec.homepage = "https://github.com/ahoward/tagz"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436
